### PR TITLE
Save Product entity with ORM ROOM

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,11 @@ dependencies {
     implementation "com.google.dagger:hilt-android:2.44"
     kapt "com.google.dagger:hilt-compiler:2.44"
 
+    //Room
+    implementation 'androidx.room:room-runtime:2.5.1'
+    kapt 'androidx.room:room-compiler:2.5.1'
+    implementation 'androidx.room:room-ktx:2.5.1'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/java/com/ada/codelabapiwithjwt/data/AppDatabase.kt
+++ b/app/src/main/java/com/ada/codelabapiwithjwt/data/AppDatabase.kt
@@ -1,0 +1,11 @@
+package com.ada.codelabapiwithjwt.data
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.ada.codelabapiwithjwt.data.dao.ProductDao
+import com.ada.codelabapiwithjwt.data.entity.Product
+
+@Database(entities = [Product::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun productDao() : ProductDao
+}

--- a/app/src/main/java/com/ada/codelabapiwithjwt/data/dao/ProductDao.kt
+++ b/app/src/main/java/com/ada/codelabapiwithjwt/data/dao/ProductDao.kt
@@ -1,0 +1,26 @@
+package com.ada.codelabapiwithjwt.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import com.ada.codelabapiwithjwt.data.entity.Product
+
+@Dao
+interface ProductDao {
+
+    @Query("SELECT * FROM product")
+    fun getAllProducts(): List<Product>
+
+    @Query("SELECT * FROM product WHERE product_id IN (:productIds)")
+    fun loadAllProductsByIds(productIds: IntArray): List<Product>
+
+    @Query("SELECT * FROM product WHERE name LIKE :nameProduct LIMIT 1")
+    fun findByNameProduct(nameProduct: String): Product
+
+    @Insert
+    fun insertAllProducts(vararg product: Product)
+
+    @Delete
+    fun deleteProduct(product: Product)
+}

--- a/app/src/main/java/com/ada/codelabapiwithjwt/data/entity/Product.kt
+++ b/app/src/main/java/com/ada/codelabapiwithjwt/data/entity/Product.kt
@@ -1,0 +1,30 @@
+package com.ada.codelabapiwithjwt.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
+data class Product(
+    @PrimaryKey(autoGenerate = true) @ColumnInfo(name = "product_id") val productId: Int? = null,
+    val category: String?,
+    val description: String?,
+    @ColumnInfo(name = "image_url")val imageUrl: String?,
+    val name: String?,
+    val price: Double?
+){
+    constructor(
+        category: String?,
+        description: String?,
+        imageUrl: String?,
+        name: String?,
+        price: Double?
+    ): this(
+        null,
+        category,
+        description,
+        imageUrl,
+        name,
+        price
+    )
+}

--- a/app/src/main/java/com/ada/codelabapiwithjwt/di/AppModule.kt
+++ b/app/src/main/java/com/ada/codelabapiwithjwt/di/AppModule.kt
@@ -1,7 +1,10 @@
 package com.ada.codelabapiwithjwt.di
 
 import android.content.Context
+import androidx.room.Room
 import com.ada.codelabapiwithjwt.SHARED_PREFERENCES_FILE_NAME
+import com.ada.codelabapiwithjwt.data.AppDatabase
+import com.ada.codelabapiwithjwt.data.dao.ProductDao
 import com.ada.codelabapiwithjwt.network.JWTInterceptor
 import com.ada.codelabapiwithjwt.network.service.AuthService
 import com.ada.codelabapiwithjwt.network.service.ProductsService
@@ -24,6 +27,19 @@ import java.util.concurrent.TimeUnit
 @Module
 @InstallIn(ActivityComponent::class)
 object AppModule {
+
+    @Provides
+    fun provideProductDao( appDatabase: AppDatabase): ProductDao{
+        return appDatabase.productDao()
+    }
+
+    @Provides
+    fun provideAppDatabase(@ApplicationContext appContext: Context): AppDatabase{
+        return Room.databaseBuilder(
+            appContext,
+            AppDatabase::class.java, "database-name"
+        ).build()
+    }
 
     @Provides
     fun provideProductService(retrofit: Retrofit): ProductsService{

--- a/app/src/main/java/com/ada/codelabapiwithjwt/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/ada/codelabapiwithjwt/ui/activity/MainActivity.kt
@@ -4,6 +4,10 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import com.ada.codelabapiwithjwt.R
+import com.ada.codelabapiwithjwt.data.AppDatabase
+import com.ada.codelabapiwithjwt.data.dao.ProductDao
+import com.ada.codelabapiwithjwt.data.entity.Product
+import com.ada.codelabapiwithjwt.network.dto.product.ProductDto
 import com.ada.codelabapiwithjwt.network.service.ProductsService
 import com.ada.codelabapiwithjwt.storage.Storage
 import dagger.hilt.android.AndroidEntryPoint
@@ -19,6 +23,12 @@ class MainActivity : AppCompatActivity() {
 
     @Inject
     lateinit var productsService: ProductsService
+
+    /*@Inject
+    lateinit var db: AppDatabase*/
+
+    @Inject
+    lateinit var productDao: ProductDao
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -37,7 +47,24 @@ class MainActivity : AppCompatActivity() {
             val response = productsService.getProducts(idProduct)
             if (response.isSuccessful){
                 Log.d("AndroidKotlinAda", "Response product with id $idProduct = ${response.body()}")
+                val responseProduct: ProductDto? = response.body()
+                saveProduct(responseProduct)
             }
+        }
+    }
+
+    private fun saveProduct(productDto: ProductDto?){
+        GlobalScope.launch {
+            val product = Product(
+                productDto?.category,
+                productDto?.description,
+                productDto?.imageUrl,
+                productDto?.name,
+                productDto?.price
+            )
+
+            productDao.insertAllProducts(product)
+            Log.d("AndroidKotlinAda", "Product saved with success")
         }
     }
 }


### PR DESCRIPTION
- Creación capa data donde se agrega clase para representar la entidad Product de la API, tambien se crea la interface que representa el DAO de Product y por ultimo la clase abstracta para crear la base de datos SQLite por medio del ORM ROOM
- Provisión de dependencia de la clase AppDatabase para instanciar la BD en la clase Modulo del contenedor a nivel de Activity
- Provisión de dependencia de la interface DAO de Product para usar las operaciones SQL sobre la entidad Product en la clase Modulo del contenedor a nivel de Activity
- Inyección de dependencia DAO de Product en la MainActivity, donde se hace consumo de la API del recurso de consulta de un producto por id con autenticación por JWT, si la respuesta es exitosa se procede a realizar persisntencia en BD SQLite en la tabla Product